### PR TITLE
Compatibility with dplyr 1.1.0

### DIFF
--- a/R/abs_cent.R
+++ b/R/abs_cent.R
@@ -72,6 +72,6 @@ ds_abs_cent <- function(.data, .cols, .name){
 #' @rdname ds_abs_cent
 #' @param ... arguments to forward to ds_abs_cent from abs_cent
 #' @export
-abs_cent <- function(..., .data = dplyr::pick(everything())) {
+abs_cent <- function(..., .data = dplyr::across(everything())) {
   ds_abs_cent(.data = .data, ...)
 }

--- a/R/abs_cent.R
+++ b/R/abs_cent.R
@@ -72,6 +72,6 @@ ds_abs_cent <- function(.data, .cols, .name){
 #' @rdname ds_abs_cent
 #' @param ... arguments to forward to ds_abs_cent from abs_cent
 #' @export
-abs_cent <- function(..., .data = dplyr::cur_data_all()) {
+abs_cent <- function(..., .data = dplyr::pick(everything())) {
   ds_abs_cent(.data = .data, ...)
 }

--- a/R/abs_cent.R
+++ b/R/abs_cent.R
@@ -46,7 +46,7 @@ ds_abs_cent <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.x = dplyr::first(dplyr::cur_data())) %>%
+    dplyr::mutate(.x = pick_n(1)) %>%
     dplyr::ungroup()
 
   .X <- sum(sub[['.x']])

--- a/R/abs_clust.R
+++ b/R/abs_clust.R
@@ -45,7 +45,7 @@ ds_abs_clust <- function(.data, .cols, .name){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data())) %>%
+                  .x = pick_n(1)) %>%
     dplyr::ungroup()
 
   .X <- sum(sub$.x)

--- a/R/abs_clust.R
+++ b/R/abs_clust.R
@@ -44,7 +44,7 @@ ds_abs_clust <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1)) %>%
     dplyr::ungroup()
 

--- a/R/abs_clust.R
+++ b/R/abs_clust.R
@@ -75,6 +75,6 @@ ds_abs_clust <- function(.data, .cols, .name){
 #' @rdname ds_abs_clust
 #' @param ... arguments to forward to ds_abs_clust from abs_clust
 #' @export
-abs_clust <- function(..., .data = dplyr::pick(everything())) {
+abs_clust <- function(..., .data = dplyr::across(everything())) {
   ds_abs_clust(.data = .data, ...)
 }

--- a/R/abs_clust.R
+++ b/R/abs_clust.R
@@ -75,6 +75,6 @@ ds_abs_clust <- function(.data, .cols, .name){
 #' @rdname ds_abs_clust
 #' @param ... arguments to forward to ds_abs_clust from abs_clust
 #' @export
-abs_clust <- function(..., .data = dplyr::cur_data_all()) {
+abs_clust <- function(..., .data = dplyr::pick(everything())) {
   ds_abs_clust(.data = .data, ...)
 }

--- a/R/abs_conc.R
+++ b/R/abs_conc.R
@@ -40,7 +40,7 @@ ds_abs_conc <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1)) %>%
     dplyr::ungroup()
 

--- a/R/abs_conc.R
+++ b/R/abs_conc.R
@@ -71,6 +71,6 @@ ds_abs_conc <- function(.data, .cols, .name){
 #' @rdname ds_abs_conc
 #' @param ... arguments to forward to ds_abs_conc from abs_conc
 #' @export
-abs_conc <- function(..., .data = dplyr::pick(everything())) {
+abs_conc <- function(..., .data = dplyr::across(everything())) {
   ds_abs_conc(.data = .data, ...)
 }

--- a/R/abs_conc.R
+++ b/R/abs_conc.R
@@ -71,6 +71,6 @@ ds_abs_conc <- function(.data, .cols, .name){
 #' @rdname ds_abs_conc
 #' @param ... arguments to forward to ds_abs_conc from abs_conc
 #' @export
-abs_conc <- function(..., .data = dplyr::cur_data_all()) {
+abs_conc <- function(..., .data = dplyr::pick(everything())) {
   ds_abs_conc(.data = .data, ...)
 }

--- a/R/abs_conc.R
+++ b/R/abs_conc.R
@@ -41,7 +41,7 @@ ds_abs_conc <- function(.data, .cols, .name){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data())) %>%
+                  .x = pick_n(1)) %>%
     dplyr::ungroup()
 
   sub$.a <- calc_area(.data)

--- a/R/atkinson.R
+++ b/R/atkinson.R
@@ -65,6 +65,6 @@ ds_atkinson <- function(.data, .cols, .name, b = 0.5) {
 #' @rdname ds_atkinson
 #' @param ... arguments to forward to ds_atkinson from atkinson
 #' @export
-atkinson <- function(..., .data = dplyr::pick(everything())) {
+atkinson <- function(..., .data = dplyr::across(everything())) {
   ds_atkinson(.data = .data, ...)
 }

--- a/R/atkinson.R
+++ b/R/atkinson.R
@@ -65,6 +65,6 @@ ds_atkinson <- function(.data, .cols, .name, b = 0.5) {
 #' @rdname ds_atkinson
 #' @param ... arguments to forward to ds_atkinson from atkinson
 #' @export
-atkinson <- function(..., .data = dplyr::cur_data_all()) {
+atkinson <- function(..., .data = dplyr::pick(everything())) {
   ds_atkinson(.data = .data, ...)
 }

--- a/R/atkinson.R
+++ b/R/atkinson.R
@@ -46,7 +46,7 @@ ds_atkinson <- function(.data, .cols, .name, b = 0.5) {
   .P <- sum(dplyr::first(sub)) / .T
 
   out <- sub %>%
-    dplyr::mutate(.p = dplyr::first(dplyr::cur_data()) / .data$.total) %>%
+    dplyr::mutate(.p = pick_n(1) / .data$.total) %>%
     dplyr::mutate(!!.name := 1 - (.P / (1 - .P)) *
                     abs((1 / (.P * .T)) *
                           sum((1 - .data$.p)^(1 - b) * .data$.p^b * .data$.total)

--- a/R/atkinson.R
+++ b/R/atkinson.R
@@ -39,7 +39,7 @@ ds_atkinson <- function(.data, .cols, .name, b = 0.5) {
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across())) %>%
+    dplyr::mutate(.total = sum(dplyr::c_across(everything()))) %>%
     dplyr::ungroup()
 
   .T <- sum(sub$.total)

--- a/R/atkinson.R
+++ b/R/atkinson.R
@@ -43,7 +43,7 @@ ds_atkinson <- function(.data, .cols, .name, b = 0.5) {
     dplyr::ungroup()
 
   .T <- sum(sub$.total)
-  .P <- sum(dplyr::first(sub)) / .T
+  .P <- sum(sub[[1]]) / .T
 
   out <- sub %>%
     dplyr::mutate(.p = pick_n(1) / .data$.total) %>%

--- a/R/blau.R
+++ b/R/blau.R
@@ -28,7 +28,7 @@ ds_blau <- function(.data, .cols, .name){
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := 1 - sum((dplyr::select(dplyr::cur_data(), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := 1 - sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -41,6 +41,6 @@ ds_blau <- function(.data, .cols, .name){
 #' @rdname ds_blau
 #' @param ... arguments to forward to ds_blau from blau
 #' @export
-blau <- function(..., .data = dplyr::cur_data_all()) {
+blau <- function(..., .data = dplyr::pick(everything())) {
   ds_blau(.data = .data, ...)
 }

--- a/R/blau.R
+++ b/R/blau.R
@@ -28,7 +28,7 @@ ds_blau <- function(.data, .cols, .name){
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := 1 - sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := 1 - sum((dplyr::select(dplyr::across(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -41,6 +41,6 @@ ds_blau <- function(.data, .cols, .name){
 #' @rdname ds_blau
 #' @param ... arguments to forward to ds_blau from blau
 #' @export
-blau <- function(..., .data = dplyr::pick(everything())) {
+blau <- function(..., .data = dplyr::across(everything())) {
   ds_blau(.data = .data, ...)
 }

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -41,7 +41,7 @@ ds_correlation <- function(.data, .cols, .name) {
 
   .X <- sum(sub$.x)
   .T <- sum(sub$.total)
-  .P <- sum(dplyr::first(sub)) / .T
+  .P <- sum(sub[[1]]) / .T
 
   out <- sub %>%
     dplyr::mutate(!!.name := (sum((.data$.x/.X)*(.data$.x/.data$.total)) - .P)/(1 - .P)) %>%

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -59,6 +59,6 @@ ds_correlation <- function(.data, .cols, .name) {
 #' @rdname ds_correlation
 #' @param ... arguments to forward to ds_correlation from correlation
 #' @export
-correlation <- function(..., .data = dplyr::cur_data_all()) {
+correlation <- function(..., .data = dplyr::pick(everything())) {
   ds_correlation(.data = .data, ...)
 }

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -59,6 +59,6 @@ ds_correlation <- function(.data, .cols, .name) {
 #' @rdname ds_correlation
 #' @param ... arguments to forward to ds_correlation from correlation
 #' @export
-correlation <- function(..., .data = dplyr::pick(everything())) {
+correlation <- function(..., .data = dplyr::across(everything())) {
   ds_correlation(.data = .data, ...)
 }

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -36,7 +36,7 @@ ds_correlation <- function(.data, .cols, .name) {
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data())) %>%
+                  .x = pick_n(1)) %>%
     dplyr::ungroup()
 
   .X <- sum(sub$.x)

--- a/R/correlation.R
+++ b/R/correlation.R
@@ -35,7 +35,7 @@ ds_correlation <- function(.data, .cols, .name) {
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1)) %>%
     dplyr::ungroup()
 

--- a/R/dd_interaction.R
+++ b/R/dd_interaction.R
@@ -71,6 +71,6 @@ ds_dd_interaction <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dd_interaction
 #' @param ... arguments to forward to ds_dd_interaction from dd_interaction
 #' @export
-dd_interaction <- function(..., .data = dplyr::pick(everything())) {
+dd_interaction <- function(..., .data = dplyr::across(everything())) {
   ds_dd_interaction(.data = .data, ...)
 }

--- a/R/dd_interaction.R
+++ b/R/dd_interaction.R
@@ -44,7 +44,7 @@ ds_dd_interaction <- function(.data, .cols, .name, .comp = FALSE){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/dd_interaction.R
+++ b/R/dd_interaction.R
@@ -43,7 +43,7 @@ ds_dd_interaction <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/dd_interaction.R
+++ b/R/dd_interaction.R
@@ -71,6 +71,6 @@ ds_dd_interaction <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dd_interaction
 #' @param ... arguments to forward to ds_dd_interaction from dd_interaction
 #' @export
-dd_interaction <- function(..., .data = dplyr::cur_data_all()) {
+dd_interaction <- function(..., .data = dplyr::pick(everything())) {
   ds_dd_interaction(.data = .data, ...)
 }

--- a/R/dd_isolation.R
+++ b/R/dd_isolation.R
@@ -44,7 +44,7 @@ ds_dd_isolation <- function(.data, .cols, .name, .comp = FALSE){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/dd_isolation.R
+++ b/R/dd_isolation.R
@@ -71,6 +71,6 @@ ds_dd_isolation <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dd_isolation
 #' @param ... arguments to forward to ds_dd_isolation from dd_isolation
 #' @export
-dd_isolation <- function(..., .data = dplyr::cur_data_all()) {
+dd_isolation <- function(..., .data = dplyr::pick(everything())) {
   ds_dd_isolation(.data = .data, ...)
 }

--- a/R/dd_isolation.R
+++ b/R/dd_isolation.R
@@ -71,6 +71,6 @@ ds_dd_isolation <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dd_isolation
 #' @param ... arguments to forward to ds_dd_isolation from dd_isolation
 #' @export
-dd_isolation <- function(..., .data = dplyr::pick(everything())) {
+dd_isolation <- function(..., .data = dplyr::across(everything())) {
   ds_dd_isolation(.data = .data, ...)
 }

--- a/R/dd_isolation.R
+++ b/R/dd_isolation.R
@@ -43,7 +43,7 @@ ds_dd_isolation <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/delta.R
+++ b/R/delta.R
@@ -64,6 +64,6 @@ ds_delta <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_delta
 #' @param ... arguments to forward to ds_delta from delta
 #' @export
-delta <- function(..., .data = dplyr::pick(everything())) {
+delta <- function(..., .data = dplyr::across(everything())) {
   ds_delta(.data = .data, ...)
 }

--- a/R/delta.R
+++ b/R/delta.R
@@ -64,6 +64,6 @@ ds_delta <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_delta
 #' @param ... arguments to forward to ds_delta from delta
 #' @export
-delta <- function(..., .data = dplyr::cur_data_all()) {
+delta <- function(..., .data = dplyr::pick(everything())) {
   ds_delta(.data = .data, ...)
 }

--- a/R/delta.R
+++ b/R/delta.R
@@ -41,7 +41,7 @@ ds_delta <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.x = dplyr::first(dplyr::cur_data())) %>%
+    dplyr::mutate(.x = pick_n(1)) %>%
     dplyr::ungroup()
 
   sub$.a <- calc_area(.data)

--- a/R/dissim.R
+++ b/R/dissim.R
@@ -59,6 +59,6 @@ ds_dissim <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dissim
 #' @param ... arguments to forward to ds_dissim from dissim
 #' @export
-dissim <- function(..., .data = dplyr::pick(everything())) {
+dissim <- function(..., .data = dplyr::across(everything())) {
   ds_dissim(.data = .data, ...)
 }

--- a/R/dissim.R
+++ b/R/dissim.R
@@ -59,6 +59,6 @@ ds_dissim <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_dissim
 #' @param ... arguments to forward to ds_dissim from dissim
 #' @export
-dissim <- function(..., .data = dplyr::cur_data_all()) {
+dissim <- function(..., .data = dplyr::pick(everything())) {
   ds_dissim(.data = .data, ...)
 }

--- a/R/dissim.R
+++ b/R/dissim.R
@@ -45,7 +45,7 @@ ds_dissim <- function(.data, .cols, .name, .comp = FALSE){
 
   out <- sub %>%
     rowwise_if(.comp) %>%
-    dplyr::mutate(!!.name := 0.5 * sum(.data$.total * abs(dplyr::first(dplyr::cur_data())/.data$.total - .P))
+    dplyr::mutate(!!.name := 0.5 * sum(.data$.total * abs(pick_n(1)/.data$.total - .P))
                   /(.T * .P * (1 - .P)) ) %>%
     dplyr::pull(!!.name)
 

--- a/R/dissim.R
+++ b/R/dissim.R
@@ -37,7 +37,7 @@ ds_dissim <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across())) %>%
+    dplyr::mutate(.total = sum(dplyr::c_across(everything()))) %>%
     dplyr::ungroup()
 
   .T <- sum(sub$.total)

--- a/R/dissim.R
+++ b/R/dissim.R
@@ -41,7 +41,7 @@ ds_dissim <- function(.data, .cols, .name, .comp = FALSE){
     dplyr::ungroup()
 
   .T <- sum(sub$.total)
-  .P <- sum(dplyr::first(sub))/.T
+  .P <- sum(sub[[1]])/.T
 
   out <- sub %>%
     rowwise_if(.comp) %>%

--- a/R/diversity.R
+++ b/R/diversity.R
@@ -31,7 +31,7 @@ ds_diversity <- function(.data, .cols, .name, q = 1) {
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name :=  sum((dplyr::select(dplyr::pick(everything()), !!.cols)
+    dplyr::mutate(!!.name :=  sum((dplyr::select(dplyr::across(everything()), !!.cols)
                                                       / .data$.total)^q)^(1 / (1 - q)) ) %>%
     dplyr::pull(!!.name)
 
@@ -47,6 +47,6 @@ ds_diversity <- function(.data, .cols, .name, q = 1) {
 #' @rdname ds_diversity
 #' @param ... arguments to forward to ds_diversity from diversity
 #' @export
-diversity <- function(..., .data = dplyr::pick(everything())) {
+diversity <- function(..., .data = dplyr::across(everything())) {
   ds_diversity(.data = .data, ...)
 }

--- a/R/diversity.R
+++ b/R/diversity.R
@@ -31,7 +31,7 @@ ds_diversity <- function(.data, .cols, .name, q = 1) {
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name :=  sum((dplyr::select(dplyr::cur_data(), !!.cols)
+    dplyr::mutate(!!.name :=  sum((dplyr::select(dplyr::pick(everything()), !!.cols)
                                                       / .data$.total)^q)^(1 / (1 - q)) ) %>%
     dplyr::pull(!!.name)
 
@@ -47,6 +47,6 @@ ds_diversity <- function(.data, .cols, .name, q = 1) {
 #' @rdname ds_diversity
 #' @param ... arguments to forward to ds_diversity from diversity
 #' @export
-diversity <- function(..., .data = dplyr::cur_data_all()) {
+diversity <- function(..., .data = dplyr::pick(everything())) {
   ds_diversity(.data = .data, ...)
 }

--- a/R/divseg-package.R
+++ b/R/divseg-package.R
@@ -5,3 +5,8 @@ NULL
 
 utils::globalVariables(c('.', 'km'))
 
+
+pick_n <- function(n) {
+  stopifnot(rlang::is_integerish(n, n = 1))
+  tibble::deframe(dplyr::across(all_of(n)))
+}

--- a/R/entropy.R
+++ b/R/entropy.R
@@ -36,7 +36,7 @@ ds_entropy <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across())) %>%
+    dplyr::mutate(.total = sum(dplyr::c_across(everything()))) %>%
     dplyr::ungroup()
 
   .T <- sum(sub$.total)

--- a/R/entropy.R
+++ b/R/entropy.R
@@ -60,6 +60,6 @@ ds_entropy <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_entropy
 #' @param ... arguments to forward to ds_entropy from entropy
 #' @export
-entropy <- function(..., .data = dplyr::pick(everything())) {
+entropy <- function(..., .data = dplyr::across(everything())) {
   ds_entropy(.data = .data, ...)
 }

--- a/R/entropy.R
+++ b/R/entropy.R
@@ -60,6 +60,6 @@ ds_entropy <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_entropy
 #' @param ... arguments to forward to ds_entropy from entropy
 #' @export
-entropy <- function(..., .data = dplyr::cur_data_all()) {
+entropy <- function(..., .data = dplyr::pick(everything())) {
   ds_entropy(.data = .data, ...)
 }

--- a/R/entropy.R
+++ b/R/entropy.R
@@ -40,7 +40,7 @@ ds_entropy <- function(.data, .cols, .name, .comp = FALSE){
     dplyr::ungroup()
 
   .T <- sum(sub$.total)
-  .P <- sum(dplyr::first(sub))/.T
+  .P <- sum(sub[[1]])/.T
   .E <- .P * plog (1/.P) + (1 - .P) * plog (1/(1 - .P))
 
   out <- sub %>%

--- a/R/entropy.R
+++ b/R/entropy.R
@@ -44,7 +44,7 @@ ds_entropy <- function(.data, .cols, .name, .comp = FALSE){
   .E <- .P * plog (1/.P) + (1 - .P) * plog (1/(1 - .P))
 
   out <- sub %>%
-    dplyr::mutate(.p = dplyr::first(dplyr::cur_data())/.data$.total,
+    dplyr::mutate(.p = pick_n(1)/.data$.total,
                   .e =  .data$.p * plog (1/.data$.p) + (1 - .data$.p) * plog (1/(1 - .data$.p))) %>%
     rowwise_if(.comp) %>%
     dplyr::mutate(!!.name := sum(.data$.total * (.E * .data$.e))/(.E * .T) ) %>%

--- a/R/gini.R
+++ b/R/gini.R
@@ -62,6 +62,6 @@ ds_gini <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_gini
 #' @param ... arguments to forward to ds_gini from gini
 #' @export
-gini <- function(..., .data = dplyr::pick(everything())) {
+gini <- function(..., .data = dplyr::across(everything())) {
   ds_gini(.data = .data, ...)
 }

--- a/R/gini.R
+++ b/R/gini.R
@@ -62,6 +62,6 @@ ds_gini <- function(.data, .cols, .name, .comp = FALSE){
 #' @rdname ds_gini
 #' @param ... arguments to forward to ds_gini from gini
 #' @export
-gini <- function(..., .data = dplyr::cur_data_all()) {
+gini <- function(..., .data = dplyr::pick(everything())) {
   ds_gini(.data = .data, ...)
 }

--- a/R/gini.R
+++ b/R/gini.R
@@ -36,7 +36,7 @@ ds_gini <- function(.data, .cols, .name, .comp = FALSE){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across())) %>%
+    dplyr::mutate(.total = sum(dplyr::c_across(everything()))) %>%
     dplyr::ungroup()
 
   .T <- sum(sub$.total)

--- a/R/gini.R
+++ b/R/gini.R
@@ -40,9 +40,9 @@ ds_gini <- function(.data, .cols, .name, .comp = FALSE){
     dplyr::ungroup()
 
   .T <- sum(sub$.total)
-  .P <- sum(dplyr::first(sub))/.T
+  .P <- sum(sub[[1]])/.T
 
-  pmat <- matrix(rep(dplyr::first(sub), nrow(sub)), ncol = nrow(sub))
+  pmat <- matrix(rep(sub[[1]], nrow(sub)), ncol = nrow(sub))
   pmat <- abs(pmat - t(pmat))
   tmat <- crossprod(t(sub$.total)/.T)
 

--- a/R/hhi.R
+++ b/R/hhi.R
@@ -29,7 +29,7 @@ ds_hhi <- function(.data, .cols, .name){
   out <- .data %>% drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := sum((dplyr::select(dplyr::cur_data(), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -42,6 +42,6 @@ ds_hhi <- function(.data, .cols, .name){
 #' @rdname ds_hhi
 #' @param ... arguments to forward to ds_hhi from hhi
 #' @export
-hhi <- function(..., .data = dplyr::cur_data_all()) {
+hhi <- function(..., .data = dplyr::pick(everything())) {
   ds_hhi(.data = .data, ...)
 }

--- a/R/hhi.R
+++ b/R/hhi.R
@@ -29,7 +29,7 @@ ds_hhi <- function(.data, .cols, .name){
   out <- .data %>% drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := sum((dplyr::select(dplyr::across(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -42,6 +42,6 @@ ds_hhi <- function(.data, .cols, .name){
 #' @rdname ds_hhi
 #' @param ... arguments to forward to ds_hhi from hhi
 #' @export
-hhi <- function(..., .data = dplyr::pick(everything())) {
+hhi <- function(..., .data = dplyr::across(everything())) {
   ds_hhi(.data = .data, ...)
 }

--- a/R/interaction.R
+++ b/R/interaction.R
@@ -58,6 +58,6 @@ ds_interaction <- function(.data, .cols, .name, .comp = FALSE) {
 #' @rdname ds_interaction
 #' @param ... arguments to forward to ds_interaction from interaction
 #' @export
-interaction <- function(..., .data = dplyr::cur_data_all()) {
+interaction <- function(..., .data = dplyr::pick(everything())) {
   ds_interaction(.data = .data, ...)
 }

--- a/R/interaction.R
+++ b/R/interaction.R
@@ -37,7 +37,7 @@ ds_interaction <- function(.data, .cols, .name, .comp = FALSE) {
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/interaction.R
+++ b/R/interaction.R
@@ -36,7 +36,7 @@ ds_interaction <- function(.data, .cols, .name, .comp = FALSE) {
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/interaction.R
+++ b/R/interaction.R
@@ -58,6 +58,6 @@ ds_interaction <- function(.data, .cols, .name, .comp = FALSE) {
 #' @rdname ds_interaction
 #' @param ... arguments to forward to ds_interaction from interaction
 #' @export
-interaction <- function(..., .data = dplyr::pick(everything())) {
+interaction <- function(..., .data = dplyr::across(everything())) {
   ds_interaction(.data = .data, ...)
 }

--- a/R/inv_simpson.R
+++ b/R/inv_simpson.R
@@ -27,7 +27,7 @@ ds_inv_simpson <- function(.data, .cols, .name){
   out <- .data %>% drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := 1/sum((dplyr::select(dplyr::cur_data(), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := 1/sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -40,6 +40,6 @@ ds_inv_simpson <- function(.data, .cols, .name){
 #' @rdname ds_inv_simpson
 #' @param ... arguments to forward to ds_inv_simpson from inv_simpson
 #' @export
-inv_simpson <- function(..., .data = dplyr::cur_data_all()) {
+inv_simpson <- function(..., .data = dplyr::pick(everything())) {
   ds_inv_simpson(.data = .data, ...)
 }

--- a/R/inv_simpson.R
+++ b/R/inv_simpson.R
@@ -27,7 +27,7 @@ ds_inv_simpson <- function(.data, .cols, .name){
   out <- .data %>% drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := 1/sum((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total)^2)) %>%
+    dplyr::mutate(!!.name := 1/sum((dplyr::select(dplyr::across(everything()), !!.cols)/.data$.total)^2)) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -40,6 +40,6 @@ ds_inv_simpson <- function(.data, .cols, .name){
 #' @rdname ds_inv_simpson
 #' @param ... arguments to forward to ds_inv_simpson from inv_simpson
 #' @export
-inv_simpson <- function(..., .data = dplyr::pick(everything())) {
+inv_simpson <- function(..., .data = dplyr::across(everything())) {
   ds_inv_simpson(.data = .data, ...)
 }

--- a/R/isolation.R
+++ b/R/isolation.R
@@ -37,7 +37,7 @@ ds_isolation <- function(.data, .cols, .name, .comp = FALSE) {
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data())) %>%
+                  .x = pick_n(1)) %>%
     dplyr::ungroup()
 
   .X <- sum(sub$.x)

--- a/R/isolation.R
+++ b/R/isolation.R
@@ -59,6 +59,6 @@ ds_isolation <- function(.data, .cols, .name, .comp = FALSE) {
 #' @rdname ds_isolation
 #' @param ... arguments to forward to ds_isolation from isolation
 #' @export
-isolation <- function(..., .data = dplyr::cur_data_all()) {
+isolation <- function(..., .data = dplyr::pick(everything())) {
   ds_isolation(.data = .data, ...)
 }

--- a/R/isolation.R
+++ b/R/isolation.R
@@ -36,7 +36,7 @@ ds_isolation <- function(.data, .cols, .name, .comp = FALSE) {
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1)) %>%
     dplyr::ungroup()
 

--- a/R/isolation.R
+++ b/R/isolation.R
@@ -59,6 +59,6 @@ ds_isolation <- function(.data, .cols, .name, .comp = FALSE) {
 #' @rdname ds_isolation
 #' @param ... arguments to forward to ds_isolation from isolation
 #' @export
-isolation <- function(..., .data = dplyr::pick(everything())) {
+isolation <- function(..., .data = dplyr::across(everything())) {
   ds_isolation(.data = .data, ...)
 }

--- a/R/rel_cent.R
+++ b/R/rel_cent.R
@@ -47,7 +47,7 @@ ds_rel_cent <- function(.data, .cols, .name){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/rel_cent.R
+++ b/R/rel_cent.R
@@ -75,6 +75,6 @@ ds_rel_cent <- function(.data, .cols, .name){
 #' @rdname ds_rel_cent
 #' @param ... arguments to forward to ds_rel_cent from rel_cent
 #' @export
-rel_cent <- function(..., .data = dplyr::pick(everything())) {
+rel_cent <- function(..., .data = dplyr::across(everything())) {
   ds_rel_cent(.data = .data, ...)
 }

--- a/R/rel_cent.R
+++ b/R/rel_cent.R
@@ -75,6 +75,6 @@ ds_rel_cent <- function(.data, .cols, .name){
 #' @rdname ds_rel_cent
 #' @param ... arguments to forward to ds_rel_cent from rel_cent
 #' @export
-rel_cent <- function(..., .data = dplyr::cur_data_all()) {
+rel_cent <- function(..., .data = dplyr::pick(everything())) {
   ds_rel_cent(.data = .data, ...)
 }

--- a/R/rel_cent.R
+++ b/R/rel_cent.R
@@ -46,7 +46,7 @@ ds_rel_cent <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/rel_clust.R
+++ b/R/rel_clust.R
@@ -43,7 +43,7 @@ ds_rel_clust <- function(.data, .cols, .name){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/rel_clust.R
+++ b/R/rel_clust.R
@@ -42,7 +42,7 @@ ds_rel_clust <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/rel_clust.R
+++ b/R/rel_clust.R
@@ -67,6 +67,6 @@ ds_rel_clust <- function(.data, .cols, .name){
 #' @rdname ds_rel_clust
 #' @param ... arguments to forward to ds_rel_clust from rel_clust
 #' @export
-rel_clust <- function(..., .data = dplyr::pick(everything())) {
+rel_clust <- function(..., .data = dplyr::across(everything())) {
   ds_rel_clust(.data = .data, ...)
 }

--- a/R/rel_clust.R
+++ b/R/rel_clust.R
@@ -67,6 +67,6 @@ ds_rel_clust <- function(.data, .cols, .name){
 #' @rdname ds_rel_clust
 #' @param ... arguments to forward to ds_rel_clust from rel_clust
 #' @export
-rel_clust <- function(..., .data = dplyr::cur_data_all()) {
+rel_clust <- function(..., .data = dplyr::pick(everything())) {
   ds_rel_clust(.data = .data, ...)
 }

--- a/R/rel_conc.R
+++ b/R/rel_conc.R
@@ -77,6 +77,6 @@ ds_rel_conc <- function(.data, .cols, .name) {
 #' @rdname ds_rel_conc
 #' @param ... arguments to forward to ds_rel_conc from rel_conc
 #' @export
-rel_conc <- function(..., .data = dplyr::pick(everything())) {
+rel_conc <- function(..., .data = dplyr::across(everything())) {
   ds_rel_conc(.data = .data, ...)
 }

--- a/R/rel_conc.R
+++ b/R/rel_conc.R
@@ -77,6 +77,6 @@ ds_rel_conc <- function(.data, .cols, .name) {
 #' @rdname ds_rel_conc
 #' @param ... arguments to forward to ds_rel_conc from rel_conc
 #' @export
-rel_conc <- function(..., .data = dplyr::cur_data_all()) {
+rel_conc <- function(..., .data = dplyr::pick(everything())) {
   ds_rel_conc(.data = .data, ...)
 }

--- a/R/rel_conc.R
+++ b/R/rel_conc.R
@@ -41,7 +41,7 @@ ds_rel_conc <- function(.data, .cols, .name) {
     dplyr::rowwise() %>%
     dplyr::mutate(
       .total = sum(dplyr::c_across()),
-      .x = dplyr::first(dplyr::cur_data()),
+      .x = pick_n(1),
       .y = .data$.total - .data$.x
     ) %>%
     dplyr::ungroup()

--- a/R/rel_conc.R
+++ b/R/rel_conc.R
@@ -40,7 +40,7 @@ ds_rel_conc <- function(.data, .cols, .name) {
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(
-      .total = sum(dplyr::c_across()),
+      .total = sum(dplyr::c_across(everything())),
       .x = pick_n(1),
       .y = .data$.total - .data$.x
     ) %>%

--- a/R/reyni.R
+++ b/R/reyni.R
@@ -32,7 +32,7 @@ ds_reyni <- function(.data, .cols, .name, q = 0) {
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := (1 / (1 - q)) * log(sum((dplyr::select(dplyr::pick(everything()), !!.cols)
+    dplyr::mutate(!!.name := (1 / (1 - q)) * log(sum((dplyr::select(dplyr::across(everything()), !!.cols)
                                                       / .data$.total)^q))) %>%
     dplyr::pull(!!.name)
 
@@ -48,6 +48,6 @@ ds_reyni <- function(.data, .cols, .name, q = 0) {
 #' @rdname ds_reyni
 #' @param ... arguments to forward to ds_reyni from reyni
 #' @export
-reyni <- function(..., .data = dplyr::pick(everything())) {
+reyni <- function(..., .data = dplyr::across(everything())) {
   ds_reyni(.data = .data, ...)
 }

--- a/R/reyni.R
+++ b/R/reyni.R
@@ -32,7 +32,7 @@ ds_reyni <- function(.data, .cols, .name, q = 0) {
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := (1 / (1 - q)) * log(sum((dplyr::select(dplyr::cur_data(), !!.cols)
+    dplyr::mutate(!!.name := (1 / (1 - q)) * log(sum((dplyr::select(dplyr::pick(everything()), !!.cols)
                                                       / .data$.total)^q))) %>%
     dplyr::pull(!!.name)
 
@@ -48,6 +48,6 @@ ds_reyni <- function(.data, .cols, .name, q = 0) {
 #' @rdname ds_reyni
 #' @param ... arguments to forward to ds_reyni from reyni
 #' @export
-reyni <- function(..., .data = dplyr::cur_data_all()) {
+reyni <- function(..., .data = dplyr::pick(everything())) {
   ds_reyni(.data = .data, ...)
 }

--- a/R/shannon.R
+++ b/R/shannon.R
@@ -28,8 +28,8 @@ ds_shannon <- function(.data, .cols, .name){
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := -1 * sum( (dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total) *
-                                           log((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total))) ) %>%
+    dplyr::mutate(!!.name := -1 * sum( (dplyr::select(dplyr::across(everything()), !!.cols)/.data$.total) *
+                                           log((dplyr::select(dplyr::across(everything()), !!.cols)/.data$.total))) ) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -42,6 +42,6 @@ ds_shannon <- function(.data, .cols, .name){
 #' @rdname ds_shannon
 #' @param ... arguments to forward to ds_shannon from shannon
 #' @export
-shannon <- function(..., .data = dplyr::pick(everything())) {
+shannon <- function(..., .data = dplyr::across(everything())) {
   ds_shannon(.data = .data, ...)
 }

--- a/R/shannon.R
+++ b/R/shannon.R
@@ -28,8 +28,8 @@ ds_shannon <- function(.data, .cols, .name){
     drop_sf() %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across(!!.cols))) %>%
-    dplyr::mutate(!!.name := -1 * sum( (dplyr::select(dplyr::cur_data(), !!.cols)/.data$.total) *
-                                           log((dplyr::select(dplyr::cur_data(), !!.cols)/.data$.total))) ) %>%
+    dplyr::mutate(!!.name := -1 * sum( (dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total) *
+                                           log((dplyr::select(dplyr::pick(everything()), !!.cols)/.data$.total))) ) %>%
     dplyr::pull(!!.name)
 
   if (ret_t) {
@@ -42,6 +42,6 @@ ds_shannon <- function(.data, .cols, .name){
 #' @rdname ds_shannon
 #' @param ... arguments to forward to ds_shannon from shannon
 #' @export
-shannon <- function(..., .data = dplyr::cur_data_all()) {
+shannon <- function(..., .data = dplyr::pick(everything())) {
   ds_shannon(.data = .data, ...)
 }

--- a/R/spat_prox.R
+++ b/R/spat_prox.R
@@ -43,7 +43,7 @@ ds_spat_prox <- function(.data, .cols, .name){
   sub <- sub %>%
     dplyr::rowwise() %>%
     dplyr::mutate(.total = sum(dplyr::c_across()),
-                  .x = dplyr::first(dplyr::cur_data()),
+                  .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()
 

--- a/R/spat_prox.R
+++ b/R/spat_prox.R
@@ -42,7 +42,7 @@ ds_spat_prox <- function(.data, .cols, .name){
 
   sub <- sub %>%
     dplyr::rowwise() %>%
-    dplyr::mutate(.total = sum(dplyr::c_across()),
+    dplyr::mutate(.total = sum(dplyr::c_across(everything())),
                   .x = pick_n(1),
                   .y = .data$.total - .data$.x) %>%
     dplyr::ungroup()

--- a/R/spat_prox.R
+++ b/R/spat_prox.R
@@ -70,6 +70,6 @@ ds_spat_prox <- function(.data, .cols, .name){
 #' @rdname ds_spat_prox
 #' @param ... arguments to forward to ds_spat_prox from spat_prox
 #' @export
-spat_prox <- function(..., .data = dplyr::cur_data_all()) {
+spat_prox <- function(..., .data = dplyr::pick(everything())) {
   ds_spat_prox(.data = .data, ...)
 }

--- a/R/spat_prox.R
+++ b/R/spat_prox.R
@@ -70,6 +70,6 @@ ds_spat_prox <- function(.data, .cols, .name){
 #' @rdname ds_spat_prox
 #' @param ... arguments to forward to ds_spat_prox from spat_prox
 #' @export
-spat_prox <- function(..., .data = dplyr::pick(everything())) {
+spat_prox <- function(..., .data = dplyr::across(everything())) {
   ds_spat_prox(.data = .data, ...)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ template_mutate <-
   "#' @rdname ``fn_name``
 #' @param ... arguments to forward to ``fn_name`` from ``fun``
 #' @export
-  ``fun`` <- function(..., .data = dplyr::cur_data_all()){
+  ``fun`` <- function(..., .data = dplyr::pick(everything())){
   ``fn_name``(.data = .data, ...)
   }"
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,7 @@ template_mutate <-
   "#' @rdname ``fn_name``
 #' @param ... arguments to forward to ``fn_name`` from ``fun``
 #' @export
-  ``fun`` <- function(..., .data = dplyr::pick(everything())){
+  ``fun`` <- function(..., .data = dplyr::across(everything())){
   ``fn_name``(.data = .data, ...)
   }"
 
@@ -54,5 +54,5 @@ use_mutate <- function(name = NULL, open = rlang::is_interactive()) {
 
 pick_n <- function(n) {
   stopifnot(rlang::is_integerish(n, n = 1))
-  tibble::deframe(dplyr::pick(all_of(n)))
+  tibble::deframe(dplyr::across(all_of(n)))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,8 +51,3 @@ use_mutate <- function(name = NULL, open = rlang::is_interactive()) {
 
   invisible(new_lines)
 }
-
-pick_n <- function(n) {
-  stopifnot(rlang::is_integerish(n, n = 1))
-  tibble::deframe(dplyr::across(all_of(n)))
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -52,3 +52,7 @@ use_mutate <- function(name = NULL, open = rlang::is_interactive()) {
   invisible(new_lines)
 }
 
+pick_n <- function(n) {
+  stopifnot(rlang::is_integerish(n, n = 1))
+  tibble::deframe(dplyr::pick(all_of(n)))
+}

--- a/man/ds_abs_cent.Rd
+++ b/man/ds_abs_cent.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_cent(.data, .cols, .name)
 
-abs_cent(..., .data = dplyr::cur_data_all())
+abs_cent(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_abs_cent.Rd
+++ b/man/ds_abs_cent.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_cent(.data, .cols, .name)
 
-abs_cent(..., .data = dplyr::pick(everything()))
+abs_cent(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_abs_clust.Rd
+++ b/man/ds_abs_clust.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_clust(.data, .cols, .name)
 
-abs_clust(..., .data = dplyr::pick(everything()))
+abs_clust(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_abs_clust.Rd
+++ b/man/ds_abs_clust.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_clust(.data, .cols, .name)
 
-abs_clust(..., .data = dplyr::cur_data_all())
+abs_clust(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_abs_conc.Rd
+++ b/man/ds_abs_conc.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_conc(.data, .cols, .name)
 
-abs_conc(..., .data = dplyr::cur_data_all())
+abs_conc(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_abs_conc.Rd
+++ b/man/ds_abs_conc.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_abs_conc(.data, .cols, .name)
 
-abs_conc(..., .data = dplyr::pick(everything()))
+abs_conc(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_atkinson.Rd
+++ b/man/ds_atkinson.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_atkinson(.data, .cols, .name, b = 0.5)
 
-atkinson(..., .data = dplyr::pick(everything()))
+atkinson(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_atkinson.Rd
+++ b/man/ds_atkinson.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_atkinson(.data, .cols, .name, b = 0.5)
 
-atkinson(..., .data = dplyr::cur_data_all())
+atkinson(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_blau.Rd
+++ b/man/ds_blau.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_blau(.data, .cols, .name)
 
-blau(..., .data = dplyr::cur_data_all())
+blau(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_blau.Rd
+++ b/man/ds_blau.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_blau(.data, .cols, .name)
 
-blau(..., .data = dplyr::pick(everything()))
+blau(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_correlation.Rd
+++ b/man/ds_correlation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_correlation(.data, .cols, .name)
 
-correlation(..., .data = dplyr::pick(everything()))
+correlation(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_correlation.Rd
+++ b/man/ds_correlation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_correlation(.data, .cols, .name)
 
-correlation(..., .data = dplyr::cur_data_all())
+correlation(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_dd_interaction.Rd
+++ b/man/ds_dd_interaction.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dd_interaction(.data, .cols, .name, .comp = FALSE)
 
-dd_interaction(..., .data = dplyr::cur_data_all())
+dd_interaction(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_dd_interaction.Rd
+++ b/man/ds_dd_interaction.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dd_interaction(.data, .cols, .name, .comp = FALSE)
 
-dd_interaction(..., .data = dplyr::pick(everything()))
+dd_interaction(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_dd_isolation.Rd
+++ b/man/ds_dd_isolation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dd_isolation(.data, .cols, .name, .comp = FALSE)
 
-dd_isolation(..., .data = dplyr::cur_data_all())
+dd_isolation(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_dd_isolation.Rd
+++ b/man/ds_dd_isolation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dd_isolation(.data, .cols, .name, .comp = FALSE)
 
-dd_isolation(..., .data = dplyr::pick(everything()))
+dd_isolation(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_delta.Rd
+++ b/man/ds_delta.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_delta(.data, .cols, .name, .comp = FALSE)
 
-delta(..., .data = dplyr::cur_data_all())
+delta(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_delta.Rd
+++ b/man/ds_delta.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_delta(.data, .cols, .name, .comp = FALSE)
 
-delta(..., .data = dplyr::pick(everything()))
+delta(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_dissim.Rd
+++ b/man/ds_dissim.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dissim(.data, .cols, .name, .comp = FALSE)
 
-dissim(..., .data = dplyr::pick(everything()))
+dissim(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_dissim.Rd
+++ b/man/ds_dissim.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_dissim(.data, .cols, .name, .comp = FALSE)
 
-dissim(..., .data = dplyr::cur_data_all())
+dissim(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_diversity.Rd
+++ b/man/ds_diversity.Rd
@@ -9,11 +9,11 @@
 \usage{
 ds_diversity(.data, .cols, .name, q = 1)
 
-diversity(..., .data = dplyr::cur_data_all())
+diversity(..., .data = dplyr::pick(everything()))
 
 ds_perplexity(.data, .cols, .name, q = 1)
 
-perplexity(..., .data = dplyr::cur_data_all())
+perplexity(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_diversity.Rd
+++ b/man/ds_diversity.Rd
@@ -9,11 +9,11 @@
 \usage{
 ds_diversity(.data, .cols, .name, q = 1)
 
-diversity(..., .data = dplyr::pick(everything()))
+diversity(..., .data = dplyr::across(everything()))
 
 ds_perplexity(.data, .cols, .name, q = 1)
 
-perplexity(..., .data = dplyr::pick(everything()))
+perplexity(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_entropy.Rd
+++ b/man/ds_entropy.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_entropy(.data, .cols, .name, .comp = FALSE)
 
-entropy(..., .data = dplyr::pick(everything()))
+entropy(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_entropy.Rd
+++ b/man/ds_entropy.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_entropy(.data, .cols, .name, .comp = FALSE)
 
-entropy(..., .data = dplyr::cur_data_all())
+entropy(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_gini.Rd
+++ b/man/ds_gini.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_gini(.data, .cols, .name, .comp = FALSE)
 
-gini(..., .data = dplyr::cur_data_all())
+gini(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_gini.Rd
+++ b/man/ds_gini.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_gini(.data, .cols, .name, .comp = FALSE)
 
-gini(..., .data = dplyr::pick(everything()))
+gini(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_hhi.Rd
+++ b/man/ds_hhi.Rd
@@ -9,11 +9,11 @@
 \usage{
 ds_hhi(.data, .cols, .name)
 
-hhi(..., .data = dplyr::cur_data_all())
+hhi(..., .data = dplyr::pick(everything()))
 
 ds_simpson(.data, .cols, .name)
 
-simpson(..., .data = dplyr::cur_data_all())
+simpson(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_hhi.Rd
+++ b/man/ds_hhi.Rd
@@ -9,11 +9,11 @@
 \usage{
 ds_hhi(.data, .cols, .name)
 
-hhi(..., .data = dplyr::pick(everything()))
+hhi(..., .data = dplyr::across(everything()))
 
 ds_simpson(.data, .cols, .name)
 
-simpson(..., .data = dplyr::pick(everything()))
+simpson(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_interaction.Rd
+++ b/man/ds_interaction.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_interaction(.data, .cols, .name, .comp = FALSE)
 
-interaction(..., .data = dplyr::cur_data_all())
+interaction(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_interaction.Rd
+++ b/man/ds_interaction.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_interaction(.data, .cols, .name, .comp = FALSE)
 
-interaction(..., .data = dplyr::pick(everything()))
+interaction(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_inv_simpson.Rd
+++ b/man/ds_inv_simpson.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_inv_simpson(.data, .cols, .name)
 
-inv_simpson(..., .data = dplyr::cur_data_all())
+inv_simpson(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_inv_simpson.Rd
+++ b/man/ds_inv_simpson.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_inv_simpson(.data, .cols, .name)
 
-inv_simpson(..., .data = dplyr::pick(everything()))
+inv_simpson(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_isolation.Rd
+++ b/man/ds_isolation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_isolation(.data, .cols, .name, .comp = FALSE)
 
-isolation(..., .data = dplyr::pick(everything()))
+isolation(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_isolation.Rd
+++ b/man/ds_isolation.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_isolation(.data, .cols, .name, .comp = FALSE)
 
-isolation(..., .data = dplyr::cur_data_all())
+isolation(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_rel_cent.Rd
+++ b/man/ds_rel_cent.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_cent(.data, .cols, .name)
 
-rel_cent(..., .data = dplyr::cur_data_all())
+rel_cent(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_rel_cent.Rd
+++ b/man/ds_rel_cent.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_cent(.data, .cols, .name)
 
-rel_cent(..., .data = dplyr::pick(everything()))
+rel_cent(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_rel_clust.Rd
+++ b/man/ds_rel_clust.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_clust(.data, .cols, .name)
 
-rel_clust(..., .data = dplyr::cur_data_all())
+rel_clust(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_rel_clust.Rd
+++ b/man/ds_rel_clust.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_clust(.data, .cols, .name)
 
-rel_clust(..., .data = dplyr::pick(everything()))
+rel_clust(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_rel_conc.Rd
+++ b/man/ds_rel_conc.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_conc(.data, .cols, .name)
 
-rel_conc(..., .data = dplyr::pick(everything()))
+rel_conc(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_rel_conc.Rd
+++ b/man/ds_rel_conc.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_rel_conc(.data, .cols, .name)
 
-rel_conc(..., .data = dplyr::cur_data_all())
+rel_conc(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_reyni.Rd
+++ b/man/ds_reyni.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_reyni(.data, .cols, .name, q = 0)
 
-reyni(..., .data = dplyr::pick(everything()))
+reyni(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_reyni.Rd
+++ b/man/ds_reyni.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_reyni(.data, .cols, .name, q = 0)
 
-reyni(..., .data = dplyr::cur_data_all())
+reyni(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_shannon.Rd
+++ b/man/ds_shannon.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_shannon(.data, .cols, .name)
 
-shannon(..., .data = dplyr::cur_data_all())
+shannon(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_shannon.Rd
+++ b/man/ds_shannon.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_shannon(.data, .cols, .name)
 
-shannon(..., .data = dplyr::pick(everything()))
+shannon(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble}}

--- a/man/ds_spat_prox.Rd
+++ b/man/ds_spat_prox.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_spat_prox(.data, .cols, .name)
 
-spat_prox(..., .data = dplyr::pick(everything()))
+spat_prox(..., .data = dplyr::across(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}

--- a/man/ds_spat_prox.Rd
+++ b/man/ds_spat_prox.Rd
@@ -7,7 +7,7 @@
 \usage{
 ds_spat_prox(.data, .cols, .name)
 
-spat_prox(..., .data = dplyr::cur_data_all())
+spat_prox(..., .data = dplyr::pick(everything()))
 }
 \arguments{
 \item{.data}{\link[tibble:tibble-package]{tibble} with sf geometry}


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

- `cur_data()` and `cur_data_all()` are deprecated in favour of `pick()`.
- `c_across()` now requires an explicit selection
- `first(df)` now selects the first row instead of the first column

Regarding `pick()` the very last commit renames it to `across()` which works equivalently to `pick()` when a mapping function is omitted. I did this so that your package is also compatible with the current version of dplyr. This way, you can send a pre-emptive release to CRAN, which would be appreciated. We plan to release on Jan 27. Then you can revert this commit once dplyr 1.1.0 is on CRAN.